### PR TITLE
[Chore] 깃헙 액션 ci 워크플로 작성

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
 permissions:
   contents: read
+  checks: write
+  pull-requests: write
 
 jobs:
   build:
@@ -39,8 +41,11 @@ jobs:
         run: ./gradlew clean build
 
       - name: 테스트 결과 리포트
-        if: always()
-        uses: actions/upload-artifact@v4
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: ${{ always() }}
         with:
-          name: test-results
-          path: build/test-results/test
+          files: build/test-results/**/*.xml
+          check_name: "test report"
+          comment_title: "Test Result"
+          fail_on: "test failures"
+          report_individual_runs: "true"


### PR DESCRIPTION
### 작업 개요
깃헙 액션 ci 워크플로 작성.

### 작업 상세 내용

- develop, main pull request 생성 시 CI를 실행하도록 구성
  - merge 전 단계에서 문제를 사전에 차단하기 위해 설정
- develop 브랜치에 push 시 CI 실행하도록 구성
  - 작업 브랜치가 merge 된 이후 통합 환경으로 합쳐지며 발생할 수 있는 충돌을 발견하고 재검증하기 위해 설정
- 저장소 코드 checkout을 위한 권한으로 `contents: read` 설정
- pull request에 test report를 위한 권한으로 `checks: write`, `pull-requests: write` 설정

### 관련 이슈
Closes #2 

### 테스트 여부
- [ ] 단위 테스트 작성
- [ ] 통합 테스트 작성
- [ ] 로컬 환경에서 정상 동작 확인
