### PR TITLE
[Feature] 공휴일 데이터 외부 API 호출 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	// Web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	// JPA
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/planitsquare/holidaykeeper/config/WebClientConfig.java
+++ b/src/main/java/com/planitsquare/holidaykeeper/config/WebClientConfig.java
@@ -1,0 +1,59 @@
+package com.planitsquare.holidaykeeper.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
+
+import java.time.Duration;
+
+@Configuration
+public class WebClientConfig {
+    private static final String HOLIDAY_API_BASE_URL = "https://date.nager.at/api/v3";
+    private static final int CONNECT_TIMEOUT_MS = 5_000;
+    private static final int TIMEOUT_SECONDS = 5;
+    private static final int MAX_CONNECTIONS = 50;
+    private static final Duration MAX_IDLE_TIME = Duration.ofSeconds(20);
+
+    @Bean
+    public WebClient holidayWebClient() {
+        return WebClient.builder()
+            .baseUrl(HOLIDAY_API_BASE_URL)
+            .clientConnector(new ReactorClientHttpConnector(httpClient()))
+            .filter(errorHandlingFilter())
+            .build();
+    }
+
+    private static HttpClient httpClient() {
+        ConnectionProvider provider = ConnectionProvider.builder("holiday-pool")
+                .maxConnections(MAX_CONNECTIONS)
+                .pendingAcquireMaxCount(1000)
+                .maxIdleTime(MAX_IDLE_TIME)
+                .build();
+
+        return HttpClient.create(provider)
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT_MS)
+                .responseTimeout(Duration.ofSeconds(TIMEOUT_SECONDS))
+                .doOnConnected(conn -> conn.addHandlerLast(new ReadTimeoutHandler(TIMEOUT_SECONDS)));
+    }
+
+    // 응답 상태 코드가 에러일 때 예외를 발생
+    private static ExchangeFilterFunction errorHandlingFilter() {
+        return ExchangeFilterFunction.ofResponseProcessor(response -> {
+            if (response.statusCode().isError()) {
+                return response.bodyToMono(String.class)
+                        .defaultIfEmpty("")
+                        .flatMap(body -> Mono.error(
+                                new RuntimeException("Holiday API Error: " + response.statusCode() + " Body: " + body)
+                        ));
+            }
+            return Mono.just(response);
+        });
+    }
+}

--- a/src/main/java/com/planitsquare/holidaykeeper/external/HolidayApiClient.java
+++ b/src/main/java/com/planitsquare/holidaykeeper/external/HolidayApiClient.java
@@ -1,0 +1,38 @@
+package com.planitsquare.holidaykeeper.external;
+
+import com.planitsquare.holidaykeeper.external.dto.CountryDto;
+import com.planitsquare.holidaykeeper.external.dto.HolidayDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static reactor.util.retry.Retry.backoff;
+
+@Component
+@RequiredArgsConstructor
+public class HolidayApiClient {
+    private final WebClient holidayWebClient;
+
+    public Mono<List<CountryDto>> getCountries() {
+        return holidayWebClient.get()
+                .uri("/AvailableCountries")
+                .retrieve()
+                .bodyToFlux(CountryDto.class)
+                .collectList()
+                .retryWhen(backoff(1, java.time.Duration.ofSeconds(1)));
+    }
+
+    public Mono<List<HolidayDto>> getHolidays(String countryCode, int year) {
+        return holidayWebClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/PublicHolidays/{year}/{country}")
+                        .build(year, countryCode))
+                .retrieve()
+                .bodyToFlux(HolidayDto.class)
+                .collectList()
+                .retryWhen(backoff(1, java.time.Duration.ofSeconds(1)));
+    }
+}

--- a/src/main/java/com/planitsquare/holidaykeeper/external/dto/CountryDto.java
+++ b/src/main/java/com/planitsquare/holidaykeeper/external/dto/CountryDto.java
@@ -1,0 +1,7 @@
+package com.planitsquare.holidaykeeper.external.dto;
+
+public record CountryDto(
+    String countryCode,
+    String name
+) {
+}

--- a/src/main/java/com/planitsquare/holidaykeeper/external/dto/HolidayDto.java
+++ b/src/main/java/com/planitsquare/holidaykeeper/external/dto/HolidayDto.java
@@ -1,0 +1,15 @@
+package com.planitsquare.holidaykeeper.external.dto;
+
+
+public record HolidayDto(
+        String date,
+        String name,
+        String localName,
+        String countryCode,
+        Boolean fixed,
+        Boolean global,
+        Integer launchYear,
+        String[] counties,
+        String[] types
+) {
+}


### PR DESCRIPTION
### 작업 개요
외부 공휴일 API(Navger.Date) 호출을 위해논블로킹 http 클라이언트 이용
(국가 개수(119개) * 5 (연도) 번의 API 호출을 적은 스레드로 빠르게 처리하기 위해 `RestTemplate`이 아닌 `WebClient` 도입)
 
### 작업 상세 내용

- WebClientConfig : connection pool, time out 등 옵션 설정, 오류 처리용 ExchangeFilterFunction 추가
- `/AvailableCountries` , `/PublicHolidays/{year}/{country}` 조회 기능 구현
  - 외부 API 호출에 대해 재시도 기본 1회 적용
- 외부 API DTO 레코드로 정의하여 getter, 생성자 등의 보일러 플레이트 코드 제거
  - `CountryDto`, `HolidayDto`

### 관련 이슈
Closes #6 

### 테스트 여부
- [ ] 단위 테스트 작성
- [ ] 통합 테스트 작성
- [x] 로컬 환경에서 정상 동작 확인
